### PR TITLE
Run Recorder in a process instead of thread.

### DIFF
--- a/timelapse/__main__.py
+++ b/timelapse/__main__.py
@@ -40,6 +40,7 @@ class Timelapse(NSObject):
 
         # Initialize recording
         self.recording = start_recording
+        self.recorder = None
 
         # Set correct output paths
         self.recorder_output_basedir = os.path.join(
@@ -96,7 +97,7 @@ class Timelapse(NSObject):
 
     def startStopRecording_(self, notification):
         if self.recording:
-            self.recorder.join()
+            self.recorder.join(timeout=screenshot_interval*2)
             # Create timelapse after recording?
             if encode:
                 self.encoder = Encoder(


### PR DESCRIPTION
Also serialise stop events. Both changes improve reliability.

## Description

In `Recorder.join()`, `Thread.join(...)` hangs. It is safe to run Recorder in a different process instead of a thread, and that solves this issue.

## Types of Changes
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Recorder thread fails to join #23 

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).