### PR TITLE
Use subprocess.run consistently v2

### DIFF
--- a/timelapse/encoder.py
+++ b/timelapse/encoder.py
@@ -41,7 +41,7 @@ class Encoder(Thread):
         """
         # Call ffmpeg with settings compatible with QuickTime.
         # https://superuser.com/a/820137
-        command = ["/usr/local/bin/ffmpeg", "-y",
+        command = ["ffmpeg", "-y",
                    "-framerate", "30",
                    "-i", self.input,
                    "-vf", "format=yuv420p",
@@ -50,11 +50,12 @@ class Encoder(Thread):
         try:
             notify("Timelapse", f"Creating timelapse. This might take a while")
             print(' '.join(command))
-            ffmpeg = subprocess.Popen(command)
-            out, err = ffmpeg.communicate()
-            if err:
-                notify("Timelapse Error: ffmpeg", err)
+            try:
+                subprocess.run(command, capture_output=True, check=True)
+            except subprocess.CalledProcessError as e:
+                notify("Timelapse Error: ffmpeg", e.stderr.decode('utf-8'))
             else:
                 notify("Timelapse", f"Movie saved to `{self.output}`")
+
         except Exception as e:
             notify("Timelapse Error", e)

--- a/timelapse/notify.py
+++ b/timelapse/notify.py
@@ -1,7 +1,6 @@
-import os
+from subprocess import run
 
 
 def notify(title, text):
-    os.system("""
-              osascript -e 'display notification "{}" with title "{}"'
-              """.format(text, title))
+    script = 'display notification "{}" with title "{}"'.format(text, title)
+    return run(['osascript', '-e', script])


### PR DESCRIPTION
Use `subprocess.run` consistently in new code for running external commands.

Consequently, a bugfix: In Encoder, do not specify path to `ffmpeg`. We test for `ffmpeg` in the user path ahead of time and so we should stick to that. Closes #29 .

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).