### PR TITLE
Make app top directory in zip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
       run: |
         cd dist
         zip -r timelapse.zip Timelapse.app
+        cd ../
         mv dist/timelapse.zip ./
 
     - name: Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,10 @@ jobs:
       run: poetry run python setup.py py2app --emulate-shell-environment
 
     - name: Compress app
-      run: zip -r timelapse.zip dist/Timelapse.app
+      shell: bash
+      run: |
+        ( cd dist; zip -r timelapse.zip Timelapse.app )
+        mv dist/timelapse.zip ./
 
     - name: Release
       uses: softprops/action-gh-release@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,9 @@ jobs:
       run: poetry run python setup.py py2app --emulate-shell-environment
 
     - name: Compress app
-      shell: bash
       run: |
-        ( cd dist; zip -r timelapse.zip Timelapse.app )
+        cd dist
+        zip -r timelapse.zip Timelapse.app
         mv dist/timelapse.zip ./
 
     - name: Release


### PR DESCRIPTION
`timelapse.zip` contains `dist/Timelapse.app`, which might confuse some end users, so might be better to have `Timelapse.app` in the `.zip` without the `dist` directory.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).