### PR TITLE
Better message when ffmpeg not found

### DIFF
--- a/timelapse/encoder.py
+++ b/timelapse/encoder.py
@@ -55,7 +55,6 @@ class Encoder(Thread):
                 completed = subprocess.run(
                     command, capture_output=True, check=True)
             except subprocess.CalledProcessError as e:
-                notify("Timelapse Error:", e.stderr.decode('utf-8'))
                 notify("Timelapse: ffmpeg not found.", e.stderr.decode('utf-8'))
             else:
                 notify("Timelapse", f"Movie saved to `{self.output}`")

--- a/timelapse/encoder.py
+++ b/timelapse/encoder.py
@@ -56,7 +56,7 @@ class Encoder(Thread):
                     command, capture_output=True, check=True)
             except subprocess.CalledProcessError as e:
                 notify("Timelapse Error:", e.stderr.decode('utf-8'))
-                notify("ffmpeg has not been installed.", not_found_msg)
+                notify("ffmpeg could not be found.", not_found_msg)
             else:
                 notify("Timelapse", f"Movie saved to `{self.output}`")
         except Exception as e:

--- a/timelapse/encoder.py
+++ b/timelapse/encoder.py
@@ -56,6 +56,7 @@ class Encoder(Thread):
                     command, capture_output=True, check=True)
             except subprocess.CalledProcessError as e:
                 notify("Timelapse Error:", e.stderr.decode('utf-8'))
+                notify("ffmpeg has not been installed.", not_found_msg)
             else:
                 notify("Timelapse", f"Movie saved to `{self.output}`")
         except Exception as e:

--- a/timelapse/encoder.py
+++ b/timelapse/encoder.py
@@ -56,7 +56,7 @@ class Encoder(Thread):
                     command, capture_output=True, check=True)
             except subprocess.CalledProcessError as e:
                 notify("Timelapse Error:", e.stderr.decode('utf-8'))
-                notify("ffmpeg could not be found.", not_found_msg)
+                notify("Timelapse: ffmpeg not found.", e.stderr.decode('utf-8'))
             else:
                 notify("Timelapse", f"Movie saved to `{self.output}`")
         except Exception as e:


### PR DESCRIPTION
Added a line to say that ffmpeg has not been installed.

PR to keep track of suggestion by @ItsThompson .

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #40 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).